### PR TITLE
Conditionally enable Log Analytics for VMs

### DIFF
--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -64,6 +64,20 @@
       "metadata": {
         "description": "Unique identifiers to allow the Azure Infrastructure to understand the origin of resources deployed to Azure. You do not need to supply a value for this."
       }
+    },
+    "logAnalyticsId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Analytics ID"
+      }
+    },
+    "logAnalyticsKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Analytics Key"
+      }
     }
   },
   "variables": {
@@ -225,6 +239,27 @@
             "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
           ],
           "properties": "[parameters('osSettings').extensionSettings.kibana]"
+        },
+        {
+          "condition": "[not(empty(parameters('logAnalyticsId')))]",
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('namespace'), '/OMSExtension')]",
+          "apiVersion": "2018-06-01",
+          "location": "[parameters('location')]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
+          ],
+          "properties": {
+            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+            "type": "OmsAgentForLinux",
+            "typeHandlerVersion": "1.7",
+            "settings": {
+              "workspaceId": "[parameters('logAnalyticsId')]"
+            },
+            "protectedSettings": {
+              "workspaceKey": "[parameters('logAnalyticsKey')]"
+            }
+          }
         }
       ]
     }

--- a/src/mainTemplate.json
+++ b/src/mainTemplate.json
@@ -1260,6 +1260,20 @@
       "metadata": {
         "description": "The Base-64 encoded certificate (.cer) used to secure the HTTP layer of Elasticsearch. Used by the Application Gateway to whitelist certificates used by the backend pool. Must be set if using esHttpCertBlob to secure the HTTP layer of Elasticsearch"
       }
+    },
+    "logAnalyticsId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Anytics ID. Used by VMs for logging."
+      }
+    },
+    "logAnalyticsKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Log Anytics Key. Used by VMs for logging."
+      }
     }
   },
   "variables": {
@@ -1896,6 +1910,8 @@
       "location": "[variables('location')]",
       "subnet": "[variables('networkSettings').subnet]",
       "subnetId": "[concat(resourceId(variables('networkSettings').resourceGroup, 'Microsoft.Network/virtualNetworks', variables('networkSettings').name), '/subnets/', variables('networkSettings').subnet.name)]",
+      "logAnalyticsId": "[parameters('logAnalyticsId')]",
+      "logAnalyticsKey": "[parameters('logAnalyticsKey')]",
       "credentials": {
         "adminUsername": "[parameters('adminUsername')]",
         "password": "[parameters('adminPassword')]",

--- a/src/partials/node-resources.json
+++ b/src/partials/node-resources.json
@@ -467,6 +467,12 @@
           },
           "elasticTags": {
             "value": "[parameters('elasticTags')]"
+          },
+          "logAnalyticsId": {
+            "value": "[parameters('commonVmSettings').logAnalyticsId]"
+          },
+          "logAnalyticsKey": {
+            "value": "[parameters('commonVmSettings').logAnalyticsKey]"
           }
         }
       }

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -153,6 +153,27 @@
             "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
           ],
           "properties": "[parameters('vm').installScript]"
+        },
+        {
+          "condition": "[not(empty(parameters('vm').shared.logAnalyticsId))]",
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('namespace'), parameters('index'), '/OMSExtension')]",
+          "apiVersion": "2018-06-01",
+          "location": "[parameters('vm').shared.location]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
+          ],
+          "properties": {
+            "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+            "type": "OmsAgentForLinux",
+            "typeHandlerVersion": "1.7",
+            "settings": {
+              "workspaceId": "[parameters('vm').shared.logAnalyticsId]"
+            },
+            "protectedSettings": {
+              "workspaceKey": "[parameters('vm').shared.logAnalyticsKey]"
+            }
+          }
         }
       ]
     }


### PR DESCRIPTION
Enables Log Analytics for VMs (which will install the OMS agent), if the
templates are supplied with Log Analytics ID and Key.