### PR TITLE
Setup JSON monitoring of Elasticsearch cluster

### DIFF
--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -168,7 +168,8 @@
         "provider": "[toUpper(parameters('elasticTags').provider)]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('securityGroupName'))]"
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('securityGroupName'))]",
+        "[concat('Microsoft.Network/applicationSecurityGroups/', variables('namespace'), '-asg')]"
       ],
       "properties": {
         "primary": true,

--- a/src/machines/kibana-resources.json
+++ b/src/machines/kibana-resources.json
@@ -237,7 +237,8 @@
           "apiVersion": "2017-12-01",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]"
+            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'))]",
+            "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('namespace'), 'OMSExtension')]"
           ],
           "properties": "[parameters('osSettings').extensionSettings.kibana]"
         },

--- a/src/partials/vm.json
+++ b/src/partials/vm.json
@@ -150,7 +150,8 @@
           "apiVersion": "2017-12-01",
           "location": "[parameters('vm').shared.location]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('namespace'), parameters('index'))]",
+            "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(variables('namespace'), parameters('index')), 'OMSExtension')]"
           ],
           "properties": "[parameters('vm').installScript]"
         },

--- a/src/scripts/custom-install.sh
+++ b/src/scripts/custom-install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+workspace_id=$1
+configfile=elasticsearch.conf
+targetdir="/etc/opt/microsoft/omsagent/$workspace_id/conf/omsagent.d"
+targetfile="$targetdir/$configfile"
+
+#export DEBIAN_FRONTEND=noninteractive
+
+log()
+{
+    echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1"
+    echo \[$(date +%d%m%Y-%H:%M:%S)\] "$1" >> /var/log/arm-install.log
+}
+
+log "Begin execution of Custom script on ${HOSTNAME}"
+START_TIME=$SECONDS
+
+log "[settings] pwd $(pwd)"
+log "[settings] ls -l $(ls -l)"
+log "[settings] workspace id = $workspace_id"
+log "[settings] configfile = $configfile"
+log "[settings] targetfile = $targetfile"
+log "[settings] ls -l $targetdir $(ls -l $targetdir)"
+
+log "[sed] Insert workspace id into config"
+sed "s/%WORKSPACE_ID%/$workspace_id/" $configfile > $targetfile
+
+log "[chown] omsagent:omiusers $targetfile"
+chown omsagent:omiusers $targetfile
+
+log "[omsagent] restart"
+/opt/microsoft/omsagent/bin/service_control restart
+
+ELAPSED_TIME=$(($SECONDS - $START_TIME))
+PRETTY=$(printf '%dh:%dm:%ds\n' $(($ELAPSED_TIME/3600)) $(($ELAPSED_TIME%3600/60)) $(($ELAPSED_TIME%60)))
+
+log "End execution of Custom script on ${HOSTNAME} in ${PRETTY}"
+exit 0

--- a/src/scripts/elasticsearch.conf
+++ b/src/scripts/elasticsearch.conf
@@ -1,0 +1,36 @@
+<source>
+  type exec
+  command 'curl localhost:9200/_cat/health?format=json'
+  format json
+  tag oms.api.es_health
+  run_interval 10s
+</source>
+
+<source>
+  type exec
+  command 'curl localhost:9200/_cat/nodes?format=json'
+  format json
+  tag oms.api.es_nodes
+  run_interval 10s
+</source>
+
+<source>
+  type exec
+  command 'curl localhost:9200/_cat/indices?format=json'
+  format json
+  tag oms.api.es_indices
+  run_interval 30s
+</source>
+
+<match oms.api.es_**>
+  type out_oms_api
+  log_level info
+
+  buffer_chunk_limit 5m
+  buffer_type file
+  buffer_path /var/opt/microsoft/omsagent/%WORKSPACE_ID%/state/out_oms_api_es_*.buffer
+  buffer_queue_limit 10
+  flush_interval 5s
+  retry_limit 10
+  retry_wait 30s
+</match>

--- a/src/settings/ubuntuSettings.json
+++ b/src/settings/ubuntuSettings.json
@@ -100,6 +100,8 @@
       "[concat(parameters('templateBaseUrl'), 'scripts/kibana-install.sh')]",
       "[concat(parameters('templateBaseUrl'), 'scripts/logstash-install.sh')]",
       "[concat(parameters('templateBaseUrl'), 'scripts/vm-disk-utils-0.1.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/custom-install.sh')]",
+      "[concat(parameters('templateBaseUrl'), 'scripts/elasticsearch.conf')]",
       "[concat(parameters('templateBaseUrl'), 'scripts/java-install.sh')]"
     ],
     "ubuntuSettings": {
@@ -144,7 +146,7 @@
             "fileUris": "[variables('ubuntuScripts')]"
           },
           "protectedSettings": {
-            "commandToExecute": "[concat('bash elasticsearch-install.sh -', variables('dataNodeShortOpt'), variables('commonShortOpts'), variables('commonInstallParams'))]"
+            "commandToExecute": "[concat('bash elasticsearch-install.sh -', variables('dataNodeShortOpt'), variables('commonShortOpts'), variables('commonInstallParams'), ' && ', 'bash custom-install.sh ', parameters('commonVmSettings').logAnalyticsId)]"
           }
         },
         "kibana": {


### PR DESCRIPTION
- Adjusts scriptiung to run custom-install.sh
- Ensures that we run scripts after OMSExtension is installed
- Sets up FluentD config for JSON logging
- Runs curl against localhost:9200/_cat/$ep
  - ep being nodes, health, indices
  - there are others if we need them